### PR TITLE
Convert table configuration to list

### DIFF
--- a/tap_s3_csv/__init__.py
+++ b/tap_s3_csv/__init__.py
@@ -82,7 +82,9 @@ def main() -> None:
     config = args.config
 
     LOGGER.info(config)
+    LOGGER.info(type(config.get('tables',{})))
     LOGGER.info(config.get('tables',{}))
+
     # Reassign the config tables to the validated object
     config['tables'] = CONFIG_CONTRACT(config.get('tables', {}))
     

--- a/tap_s3_csv/__init__.py
+++ b/tap_s3_csv/__init__.py
@@ -95,8 +95,8 @@ def main() -> None:
         do_discover(args.config)
     elif args.properties:
         do_sync(config, args.properties, args.state)
-    elif args.config:
-        do_sync(config, args.config.to_dict(), args.state)
+    elif args.catalog:
+        do_sync(config, args.catalog.to_dict(), args.state)
 
 
 if __name__ == '__main__':

--- a/tap_s3_csv/__init__.py
+++ b/tap_s3_csv/__init__.py
@@ -81,12 +81,11 @@ def main() -> None:
     args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
     config = args.config
 
-    LOGGER.info(config)
     LOGGER.info(type(config.get('tables',{})))
     LOGGER.info(config.get('tables',{}))
 
     # Reassign the config tables to the validated object
-    config['tables'] = CONFIG_CONTRACT(config.get('tables', {}))
+    config['tables'] = CONFIG_CONTRACT(list(config.get('tables', {})))
     
     try:
         for _ in s3.list_files_in_bucket(config['bucket']):

--- a/tap_s3_csv/__init__.py
+++ b/tap_s3_csv/__init__.py
@@ -82,14 +82,9 @@ def main() -> None:
     args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
     config = args.config
 
-    LOGGER.info(type(config.get('tables',{})))
-    LOGGER.info(config.get('tables',{}))
-
     #convert the config tables to a list
     configlist = ast.literal_eval(config.get('tables',{}))
    
-    LOGGER.info(type(configlist))
-    LOGGER.info(configlist)
     # Reassign the config tables to the validated object
     config['tables'] = CONFIG_CONTRACT(configlist)
     

--- a/tap_s3_csv/__init__.py
+++ b/tap_s3_csv/__init__.py
@@ -5,6 +5,7 @@ Tap S3 csv main script
 import sys
 import ujson
 import singer
+import ast
 
 from typing import Dict
 from singer import metadata, get_logger
@@ -84,8 +85,13 @@ def main() -> None:
     LOGGER.info(type(config.get('tables',{})))
     LOGGER.info(config.get('tables',{}))
 
+    #convert the config tables to a list
+    configlist = ast.literal_eval(config.get('tables',{}))
+   
+    LOGGER.info(type(configlist))
+    LOGGER.info(configlist)
     # Reassign the config tables to the validated object
-    config['tables'] = CONFIG_CONTRACT(list(config.get('tables', {})))
+    config['tables'] = CONFIG_CONTRACT(configlist)
     
     try:
         for _ in s3.list_files_in_bucket(config['bucket']):

--- a/tap_s3_csv/__init__.py
+++ b/tap_s3_csv/__init__.py
@@ -81,9 +81,11 @@ def main() -> None:
     args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
     config = args.config
 
+    LOGGER.info(config)
+    LOGGER.info(config.get('tables',{}))
     # Reassign the config tables to the validated object
     config['tables'] = CONFIG_CONTRACT(config.get('tables', {}))
-
+    
     try:
         for _ in s3.list_files_in_bucket(config['bucket']):
             break

--- a/tap_s3_csv/__init__.py
+++ b/tap_s3_csv/__init__.py
@@ -95,6 +95,8 @@ def main() -> None:
         do_discover(args.config)
     elif args.properties:
         do_sync(config, args.properties, args.state)
+    elif args.config:
+        do_sync(config, args.config.to_dict(), args.state)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Convert table configuration to list (DAS-8589)

Terraform passes the table configuration to the tap as a string, which cases the type check to fail. By converting the table configuration to a list, the tap is able to continue normally. 